### PR TITLE
feat(paperless-ng): change to official docker image

### DIFF
--- a/mirror/paperless-ng/Dockerfile
+++ b/mirror/paperless-ng/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/linuxserver/paperless-ng:1.5.0@sha256:091be4429334810fcc09cb0581ecabc441144b4ec14271ff6ee02fb641cf8868
+FROM jonaswinkler/paperless-ng:v1.5.0@sha256:e4102d1b850c9a54f7ac1f3a0be197f451ad36ae165b43aa9829714e1d582ca8
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"


### PR DESCRIPTION
Only merge after https://github.com/truecharts/apps/pull/1552 is done.