### PR TITLE
feat(airsonic-advanced): add official image

### DIFF
--- a/mirror/airsonic-advanced/Dockerfile
+++ b/mirror/airsonic-advanced/Dockerfile
@@ -1,0 +1,2 @@
+FROM airsonicadvanced/airsonic-advanced:edge-11.0.0-SNAPSHOT.20220109073049@sha256:4f1d4d1510d4f916fce401d4403424e2ef91c04df633c734998ed81bc0ddf6a9
+LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"

--- a/mirror/airsonic-advanced/PLATFORM
+++ b/mirror/airsonic-advanced/PLATFORM
@@ -1,0 +1,1 @@
+linux/amd64


### PR DESCRIPTION
Reason for the `edge` and not `stable` tag, is that `stable` is almost 2 years old. 
Upstream only do releases in `edge`