### PR TITLE
update joplin-server image

### DIFF
--- a/mirror/joplin-server/Dockerfile
+++ b/mirror/joplin-server/Dockerfile
@@ -1,2 +1,2 @@
-FROM joplin/server:2.5.1@sha256:5bd976f19f883352bacad74767237471941cb35b2ded96a1afeeb7168b1e08d8
+FROM joplin/server:2.7.3-beta@sha256:17100fc5349199b8398ede4f7079f0ecbfbc5cca5a9e5fbcb17660f9b8496330
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"


### PR DESCRIPTION
According to this: https://discourse.joplinapp.org/t/joplin-server-tag-latest-update/19137
Whole project is considered beta for now, so there will only be "beta" docker images.

