### PR TITLE
update deluge image

### DIFF
--- a/mirror/deluge/Dockerfile
+++ b/mirror/deluge/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/linuxserver/deluge:version-2.0.3-2201906121747ubuntu18.04.1@sha256:2ce561a95e7be890c1daf718e85e37fd58d792ac86ec031d1dd22f85e5311469
+FROM ghcr.io/linuxserver/deluge:2.0.5@sha256:0e18f3ee2733b04abb64ca6a5040d83a363f95fd0dadcd63236556672a8eba58
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"


### PR DESCRIPTION
They seem to released semver tags (this is the first on this image). Hopefully it will stay that way