### PR TITLE
Add Deemix mirror dockerfile

### DIFF
--- a/mirror/deemix/Dockerfile
+++ b/mirror/deemix/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.gitlab.com/bockiii/deemix-docker:latest@sha256:c38cf91d6c069630359e4368ef7f1a56b7d1df37893c87f3e3c59aaef05db2d0
+LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"

--- a/mirror/deemix/PLATFORM
+++ b/mirror/deemix/PLATFORM
@@ -1,0 +1,1 @@
+linux/amd64


### PR DESCRIPTION
As per https://github.com/truecharts/apps/pull/1933#discussion_r812116376 

a mirror for deemix docker for PR https://github.com/truecharts/apps/pull/1933