### PR TITLE
add grist

### DIFF
--- a/mirror/grist/Dockerfile
+++ b/mirror/grist/Dockerfile
@@ -1,0 +1,2 @@
+FROM gristlabs/grist:latest@sha256:f28bc8762e602d5a4c0ef368ee3c8abe7b26bc4b90c7ad4ebc21e7b3ac7b3e70
+LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"

--- a/mirror/grist/PLATFORM
+++ b/mirror/grist/PLATFORM
@@ -1,0 +1,1 @@
+linux/amd64


### PR DESCRIPTION
Reason for using `latest`: Last tagged image is 6months old. 
https://github.com/gristlabs/grist-core/issues/155