### PR TITLE
adjust version tag for kimai

### DIFF
--- a/.github/workflows/containers.build.yaml
+++ b/.github/workflows/containers.build.yaml
@@ -100,6 +100,7 @@ jobs:
           VERSION=$(echo $VERSION | sed "s/release_//g")
           VERSION=$(echo $VERSION | sed "s/version-//g")
           VERSION=$(echo $VERSION | sed "s/version_//g")
+          VERSION=$(echo $VERSION | sed "s/apache-//g")
           VERSION="${VERSION#*V.}"
           VERSION="${VERSION#*v.}"
           VERSION="${VERSION#*v-}"


### PR DESCRIPTION
kimai has `apache-` infront of version.
This should remove it, right?