### PR TITLE
nextcloud: chmod +x `includes/` scripts

### DIFF
--- a/mirror/nextcloud/Dockerfile
+++ b/mirror/nextcloud/Dockerfile
@@ -48,8 +48,8 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
-COPY ./mirror/nextcloud/includes/jumpstart.sh /jumpstart.sh
-COPY ./mirror/nextcloud/includes/hpb.sh /hpb.sh
+COPY --chmod=755 ./mirror/nextcloud/includes/jumpstart.sh /jumpstart.sh
+COPY --chmod=755 ./mirror/nextcloud/includes/hpb.sh /hpb.sh
 
 CMD ["sh /jumpstart.sh"]
 


### PR DESCRIPTION
⚒️ Fixes 

https://github.com/truecharts/apps/issues/2984

**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Add execute permissions to nextcloud `includes/` scripts.

When deploying the latest nextcloud image on TrueNAS scale (`24.0.2_14.0.10`):

```text
tccr.io/truecharts/nextcloud:v24.0.2@sha256:910679f20019efe8b2e80daf225e2c9ebd0577315d75e67eebf3b056654b4ab7
```

... the following error occurs:

```text
2022-06-25T18:46:08.759338526Z /entrypoint.sh: 222: exec: sh /jumpstart.sh: not found
```

The issue can be reproduced by running the following command:

```shell
docker run -it --entrypoint "sh /jumpstart.sh" tccr.io/truecharts/nextcloud:v24.0.2@sha256:910679f20019efe8b2e80daf225e2c9ebd0577315d75e67eebf3b056654b4ab7
```

`ls -l` inside the container reveals that the execute bits are missing from the includes scripts.

```text
drwxr-xr-x   2 root root   88 Jun 22 01:06 bin
drwxr-xr-x   2 root root    2 Mar 19 13:46 boot
-rwxrwxr-x   1 root root   61 Jun 21 23:48 cron.sh
drwxr-xr-x   5 root root  360 Jun 26 00:43 dev
-rwxrwxr-x   1 root root 9947 Jun 21 23:48 entrypoint.sh
drwxr-xr-x  48 root root  105 Jun 26 00:43 etc
drwxr-xr-x   2 root root    2 Mar 19 13:46 home
-rw-r--r--   1 root root  103 Jun 22 01:05 hpb.sh
-rw-r--r--   1 root root  464 Jun 22 01:05 jumpstart.sh
drwxr-xr-x   8 root root    9 May 28 08:08 lib
drwxr-xr-x   2 root root    3 May 27 00:00 lib64
drwxr-xr-x   2 root root    2 May 27 00:00 media
drwxr-xr-x   2 root root    2 May 27 00:00 mnt
drwxr-xr-x   2 root root    2 May 27 00:00 opt
dr-xr-xr-x 712 root root    0 Jun 26 00:43 proc
drwx------   2 root root    4 Jun 10 00:53 root
drwxr-xr-x   5 root root    6 Jun 22 01:06 run
drwxr-xr-x   2 root root   64 May 28 08:12 sbin
drwxr-xr-x   2 root root    2 May 27 00:00 srv
dr-xr-xr-x  13 root root    0 Jun 26 00:43 sys
drwxrwxrwt   3 root root    3 Jun 22 01:06 tmp
-rw-rw-r--   1 root root   78 Jun 21 23:48 upgrade.exclude
drwxr-xr-x  11 root root   11 May 27 00:00 usr
drwxr-xr-x  12 root root   14 May 28 08:09 var
```

They're set inside the git repo, so the execute flags must be lost somewhere along the deployment pipeline. 🤷 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

```shell
docker run -it --entrypoint sh tccr.io/truecharts/nextcloud:v24.0.2@sha256:910679f20019efe8b2e80daf225e2c9ebd0577315d75e67eebf3b056654b4ab7
chmod +x /jumpstart.sh
/jumpstart.sh
```

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
