### PR TITLE
fix(linkace): `chmod a+w /app/.env`

### DIFF
--- a/mirror/linkace/Dockerfile
+++ b/mirror/linkace/Dockerfile
@@ -2,6 +2,7 @@ FROM linkace/linkace:v1.10.2-simple@sha256:3f6b38b698b8792d37b2ba90953deefbc9159
 
 # Make /app/.env writable, so the user doesn't have to manually chmod by using
 # the container shell for the initial Linkace setup.
+# Workaround for upstream issue: https://github.com/Kovah/LinkAce/issues/499
 RUN chmod a+w /app/.env
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"

--- a/mirror/linkace/Dockerfile
+++ b/mirror/linkace/Dockerfile
@@ -1,5 +1,7 @@
 FROM linkace/linkace:v1.10.2-simple@sha256:3f6b38b698b8792d37b2ba90953deefbc9159d44e27344dd78b4b2f65faa6185
 
+# Make /app/.env writable, so the user doesn't have to manually chmod by using
+# the container shell for the initial Linkace setup.
 RUN chmod a+w /app/.env
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"

--- a/mirror/linkace/Dockerfile
+++ b/mirror/linkace/Dockerfile
@@ -1,2 +1,5 @@
 FROM linkace/linkace:v1.10.2-simple@sha256:3f6b38b698b8792d37b2ba90953deefbc9159d44e27344dd78b4b2f65faa6185
+
+RUN chmod a+w /app/.env
+
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"


### PR DESCRIPTION
**Description**

Makes `/app/.env` writable, so the user doesn't have to use the container shell and `chmod` to be able to finish the initial Linkace setup.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
