### PR TITLE
fix(images): update photoprism/photoprism docker tag to v221105-jammy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -93,7 +93,7 @@
     },
     {
       "matchDatasources": ["docker"],
-      "versioning": "regex:^(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})-bullseye$",
+      "versioning": "regex:^(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})-jammy$",
       "matchPackageNames": ["photoprism/photoprism"],
       "automerge": true,
     },

--- a/mirror/photoprism/Dockerfile
+++ b/mirror/photoprism/Dockerfile
@@ -1,4 +1,4 @@
-FROM photoprism/photoprism:221105-bullseye@sha256:52f2cfb9f46aec44dd2dec87c78ca121cc6fd174510db1ac371072c527f86558
+FROM photoprism/photoprism:221105-jammy@sha256:880d8a4cbb2cf80490d9f736b5f5ac8b643ed19308034f8b526690717c186f75
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 


### PR DESCRIPTION

**Description**
Based on discussion with app maintainer,  the preferred docker image for photoprism has moved from debian based (bullseye) targets to ubuntu (jammy) targets. The debian based docker targets are no longer feature complete!

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

Target change for docker image. 

**🧪 How Has This Been Tested?**
Tested locally

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [✔️ ] ⚖️ My code follows the style guidelines of this project
- [ ✔️] 👀 I have performed a self-review of my own code
- [ ✔️] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ✔️] 📄 I have made corresponding changes to the documentation
- [ ✔️] ⚠️ My changes generate no new warnings
- [✔️ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [✔️ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**
