### PR TITLE
fix(kitchenowl) set to latest tag

### DIFF
--- a/mirror/kitchenowl-backend/Dockerfile
+++ b/mirror/kitchenowl-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM tombursch/kitchenowl:beta@sha256:2a4bc7d9dd2286bf82b00e39d5807228e6eff4480e1d9a13935a8c6a55e27aad
+FROM tombursch/kitchenowl:latest@sha256:12429350125c4ca4403d59a061a88735ff457f1d39555e3b785870e62f7bf308
 LABEL org.opencontainers.image.source=https://github.com/truecharts/containers
 ARG CONTAINER_NAME
 ARG CONTAINER_VER

--- a/mirror/kitchenowl-web/Dockerfile
+++ b/mirror/kitchenowl-web/Dockerfile
@@ -1,4 +1,4 @@
-FROM tombursch/kitchenowl-web:beta@sha256:3c66d99452198495db1839a3e19393b7ee7497f746ccd1155d044ca3ad10b48e
+FROM tombursch/kitchenowl-web:latest@sha256:edcb9d526c76ef891d8ac157af3e4aca12fc750efc2c91767b2f393fc85d788d
 LABEL org.opencontainers.image.source=https://github.com/truecharts/containers
 ARG CONTAINER_NAME
 ARG CONTAINER_VER


### PR DESCRIPTION
**Description**
set containers from beta to latest tag.
⚒️ Fixes  #https://github.com/truecharts/charts/issues/5845

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
