### PR TITLE
fix(images): move ghcr.io/linuxserver/sickgear to sickgear/sickgear

### DIFF
--- a/mirror/sickgear/Dockerfile
+++ b/mirror/sickgear/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/sickgear:version-release_0.25.26@sha256:d0a88e523169a9735d8dd23184f8995e1786ebcf86190f16506233ba3fdc15a3
+FROM sickgear/sickgear:latest@sha256:85dac5001b46ccacec7b008bc32e59a64c576fd191a0f6220a089ad1ef002e2b
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 
 ARG CONTAINER_NAME


### PR DESCRIPTION
**Description**

Use the official image for sickgear instead of the LinuxServer.io image.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Pulled the image locally and tested on my TrueNAS SCALE system with my existing /config PVC.

**📃 Notes:**

This image supports /config as well as the PUID and PGID environment variables.  It seems like a drop-in to avoid the slow chown start up issues in BlueFin.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._

---

I wasn't sure if a change in truecharts/charts would be required for this or if the next automatic updating action would just take care of things.  Please let me know and I'll open any other necessary PRs if this is a change that has a chance to land.  Thanks for your time.