### PR TITLE
fix(plex): Add newline to printf of umask

### DIFF
--- a/mirror/plex/Dockerfile
+++ b/mirror/plex/Dockerfile
@@ -22,7 +22,7 @@ RUN \
     /var/tmp/ \
   && chown -R kah:kah "${PLEX_MEDIA_SERVER_HOME}" \
   && chmod -R u=rwX,go=rX "${PLEX_MEDIA_SERVER_HOME}" \
-  && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc
+  && printf "umask %d\n" "${UMASK}" >> /etc/bash.bashrc
 
   USER kah
 


### PR DESCRIPTION
**Description**

When connecting to the Plex app's container with the shell, an error is printed about parsing an octal value for the umask.  The problem is that the /etc/bash.bashrc file ends with "umask 2umask 2" because both the upstream Dockerfile and this Dockerfile do not include newlines when adding the umask command to /etc/bash.bashrc.  The full fix won't be realized until upstream changes as well, but I opened [this PR there](https://github.com/onedr0p/containers/pull/134) so I don't think working around the issue here is strictly necessary.

⚒️ Fixes

No open issue, but the umask set in the Dockerfile for the /etc/bash.bashrc is not being honored.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Not at all.  But the risk is also incredibly low.

**📃 Notes:**

Waiting on [an upstream PR](https://github.com/onedr0p/containers/pull/134) before this is fully fixed.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
