### PR TITLE
fix(images): Update valheim-server latest to 65fcb2c

### DIFF
--- a/mirror/valheim-server/Dockerfile
+++ b/mirror/valheim-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lloesche/valheim-server:latest@sha256:8eac1d70b52dc1179cb7fc2f1041eefeec19ffcea712383d10e6c8c45f24484f
+FROM ghcr.io/lloesche/valheim-server:latest@sha256:65fcb2c995651a89433485b2b570ae9b66d60f6a0451d07e251b6be2e75b880f
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 
 ARG CONTAINER_NAME


### PR DESCRIPTION
**Description**
Updating Valheim server container to be in-sync with latest digest: https://github.com/lloesche/valheim-server-docker/pkgs/container/valheim-server

This specific change is required to have this application usable when user configures Valheim Plus.
Latest official version of Valheim Plus is incompatible with the latest game version. Unofficial fix was made and valheim-server added support for configuring of repository via env variable in [this merged PR](https://github.com/lloesche/valheim-server-docker/pull/599). 


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

