### PR TITLE
feat(socat): Change stale base

### DIFF
--- a/mirror/socat/Dockerfile
+++ b/mirror/socat/Dockerfile
@@ -1,5 +1,6 @@
-FROM tynor88/socat:latest@sha256:5b13a77e0e2743b72bb51085e6a76bd63381d54ec76bf5c61133543f771337da
+FROM docker.io/alpine/socat:1.7.4.4@sha256:8c1b44c58dcc6a63aa231c14b4e7fc237eec6d3b93cc0c88538fa4edba3921f9
 LABEL org.opencontainers.image.source=https://github.com/truecharts/containers
+
 ARG CONTAINER_NAME
 ARG CONTAINER_VER
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Haven't raised an issue but changing the base image as it is quite stale (7 years old on docker hub).

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
It hasn't been. Not sure if it's needed I just copied the new image base from docker hub. I use the same image and tag for https://github.com/truecharts/charts/pull/9287.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

Specifically making this PR so I can use the image in https://github.com/truecharts/charts/pull/9287

Not sure if I need to do anything else to get this image release in tccr.io. Let me know if so.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
