### PR TITLE
fix(doublecommander): Update EXTREMELY old container

### DIFF
--- a/mirror/doublecommander/Dockerfile
+++ b/mirror/doublecommander/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/doublecommander:0.9.8@sha256:362d5ea2a4b83603235c9184f9efbf59496c1d931662847baacc5f0234883604
+FROM ghcr.io/linuxserver/doublecommander:latest@sha256:61753b3bd2695f4412201a300008871dda1cd951afd89b772ba9f1791c54b65c
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 
 ARG CONTAINER_NAME


### PR DESCRIPTION
**Description**

This container was last updated a year ago (see screenshot) below so might be a breaking change for some, I actually tested it as a direct replacement using `k3s kubectl edit deploy` and changing the image and worked fine, so we should label this a break change before merging on the `charts` repo.

<img width="1189" alt="image" src="https://github.com/truecharts/containers/assets/89483932/e1ed0aa7-4d4a-4620-af1d-63e7a391929b">

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
