### PR TITLE
fix(minecraft-java) bump version

### DIFF
--- a/mirror/minecraft-java/Dockerfile
+++ b/mirror/minecraft-java/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1@sha256:c762234f5e318c96fb32ea42b12c43112e24abe7e6d0b29cf98a31f73d48d36d
+FROM itzg/minecraft-server:2023.8.3@sha256:2af12eac3a7106882e23d1b2435358db841c4302d213532e415255fbbd36c826
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java11-jdk/Dockerfile
+++ b/mirror/minecraft-java11-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java11-jdk@sha256:4f0a5fc81da5f1437848d4146f8d8c2211f649aa31aa12d2e625c1e79ece8d0f
+FROM itzg/minecraft-server:2023.8.3-java11-jdk@sha256:13c6f5ccce16d7d599bd3bce355209c39714eab9b7f93701b4ce11627e38031b
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java11-openj9/Dockerfile
+++ b/mirror/minecraft-java11-openj9/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java11-openj9@sha256:ae93f38f2f33f38084f0b863fe9b48f636ec544b22552b57e1d6fab018a1996d
+FROM itzg/minecraft-server:2023.8.2-java11-openj9@sha256:02df151227425a530102e88caea1a0f12f52fea94682a451d7a150279d8dafe0
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java11/Dockerfile
+++ b/mirror/minecraft-java11/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java11@sha256:4f9151e74cfad63bb10689e9cef4bc51eef5811b91e6d21a679107cca626407f
+FROM itzg/minecraft-server:2023.8.3-java11@sha256:536223fac6f3c576907ea22640124942094b87bf94edabb1f106218d90274374
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java17-alpine/Dockerfile
+++ b/mirror/minecraft-java17-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java17-alpine@sha256:71cc0b22b853ed2e344ede771494abec7f79ce637d0385edb5adb1ed95b7cf9d
+FROM itzg/minecraft-server:2023.8.2-java17-alpine@sha256:7035083e6b0e7c77c0bff1601ad061eb35547621933fc070af831ee8d10b665f
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java17-graalvm-ce/Dockerfile
+++ b/mirror/minecraft-java17-graalvm-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java17-graalvm-ce@sha256:9ba286cf377e8f4203fd2e855967e0bb08e7a4fe4a9b1d9aa1211548e037f6b5
+FROM itzg/minecraft-server:2023.8.3-java17-graalvm-ce@sha256:9e7a9b67db056ae94eb3dd98b6d02b86112638dd306747090a77766ca0e01447
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java17-jdk/Dockerfile
+++ b/mirror/minecraft-java17-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java17-jdk@sha256:263a9b01ca4c985dbbd648e94aad1f7cf8a6f062695db29046622e0a396961e4
+FROM itzg/minecraft-server:2023.8.2-java17-jdk@sha256:e2d7c26bad68318d0f3f08c405455cbb6372f5df352bc7d11c62a14119b7d76a
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java17-openj9/Dockerfile
+++ b/mirror/minecraft-java17-openj9/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java17-openj9@sha256:a3229931168a98deda81d6419a2e9692765eab645f2d7c942c25ffb475c89bbc
+FROM itzg/minecraft-server:2023.8.3-java17-openj9@sha256:1598bacb87b18984257501acbc8fb3d6babbd4a1c4dd188f0877fc3e600f3fdd
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java20-alpine/Dockerfile
+++ b/mirror/minecraft-java20-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java20-alpine@sha256:2243a73756fc056e1ee41f77b0a2c8759e36094eededb8e4454b131ff13c2a44
+FROM itzg/minecraft-server:2023.8.3-java20-alpine@sha256:2f005c2417abd30b66c640fae0953a687550256bc1e18e59d90800311338e8a9
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java20/Dockerfile
+++ b/mirror/minecraft-java20/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java20@sha256:13c53448e06b47a410a2650450cbf375a2d761238af20b627f1909cfd9372708
+FROM itzg/minecraft-server:2023.8.3-java20@sha256:29023fbcfd3a36ae403f9879c780090ba63109525af901dddf249e544cafecef
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java8-graalvm-ce/Dockerfile
+++ b/mirror/minecraft-java8-graalvm-ce/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java8-graalvm-ce@sha256:1353fb0a1c0369591cd148a9fdf93c55625a939589f11422b412775f7749663c
+FROM itzg/minecraft-server:2023.8.3-java8-graalvm-ce@sha256:bc4b660b13f99398c21b83915034e640a8c6ee5021f6fb34e1a8b091cada8d97
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java8-jdk/Dockerfile
+++ b/mirror/minecraft-java8-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java8-jdk@sha256:f35e19c0a05c6ac9cdd762947233bea060827cbf54357bc58864ac5a651ee4e7
+FROM itzg/minecraft-server:2023.8.3-java8-jdk@sha256:eaec7a499b74c084a1a390a79fa2d88fef08ca39f9bb0e5c31a2943a3025f91c
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java8-openj9/Dockerfile
+++ b/mirror/minecraft-java8-openj9/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.0-java8-openj9@sha256:a34c69c3ef86119d85db4f74d0a12153ae2d5d60fcdaaaf9d418f582d9d51f12
+FROM itzg/minecraft-server:2023.8.3-java8-openj9@sha256:fc05cd0ae9b37a638e2549001d951c662b359a355e3c6ba28d7e0454e71b14cd
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 

--- a/mirror/minecraft-java8/Dockerfile
+++ b/mirror/minecraft-java8/Dockerfile
@@ -1,4 +1,4 @@
-FROM itzg/minecraft-server:2023.4.1-java8@sha256:704bed95132e2925b4c14589245465a9461bce4b1fd435ccc2cebabf4ef65345
+FROM itzg/minecraft-server:2023.8.3-java8@sha256:caba3fd4044ea240a859d7c63a50a278dbd6f4163bf50b922aa36e4109b8023f
 
 LABEL "org.opencontainers.image.source"="https://github.com/truecharts/containers"
 


### PR DESCRIPTION
**Description**
bump chart version.

the following images do not get a semver image in our quay backend.
-java8
-graalvm-ce
-java11
-java17-jdk
-java17-graalvm-ce
-java20
-java20-apline

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
