### PR TITLE
fix(nextcloud): use correct data type for image preview config

### DIFF
--- a/apps/nextcloud-fpm/configure-scripts/occ-preview-generator.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-preview-generator.sh
@@ -15,11 +15,11 @@ occ_preview_generator_install() {
 
   echo '## Configuring Preview Generation Configuration...'
   occ config:system:set enable_previews --value=true
-  occ config:system:set jpeg_quality --value="${NX_JPEG_QUALITY:-60}"
-  occ config:system:set preview_max_x --value="${NX_PREVIEW_MAX_X:-2048}"
-  occ config:system:set preview_max_y --value="${NX_PREVIEW_MAX_Y:-2048}"
-  occ config:system:set preview_max_memory --value="${NX_PREVIEW_MAX_MEMORY:-1024}"
-  occ config:system:set preview_max_filesize_image --value="${NX_PREVIEW_MAX_FILESIZE_IMAGE:-50}"
+  occ config:system:set jpeg_quality --value="${NX_JPEG_QUALITY:-60}" --type=integer
+  occ config:system:set preview_max_x --value="${NX_PREVIEW_MAX_X:-2048}" --type=integer
+  occ config:system:set preview_max_y --value="${NX_PREVIEW_MAX_Y:-2048}" --type=integer
+  occ config:system:set preview_max_memory --value="${NX_PREVIEW_MAX_MEMORY:-1024}" --type=integer
+  occ config:system:set preview_max_filesize_image --value="${NX_PREVIEW_MAX_FILESIZE_IMAGE:-50}" --type=integer
   occ config:app:set previewgenerator squareSizes --value="${NX_PREVIEW_SQUARE_SIZES:-32 256}"
   occ config:app:set previewgenerator widthSizes --value="${NX_PREVIEW_WIDTH_SIZES:-256 384}"
   occ config:app:set previewgenerator heightSizes --value="${NX_PREVIEW_HEIGHT_SIZES:-256}"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

When using the Nextcloud Memories app, errors related to wrong data types in the config occur, e.g. "Invalid type for system config preview_max_x, expected integer, got string". This PR appends flags to the Preview Generation Configuration to set related values to type `integer` instead of string.

⚒️ Fixes  truecharts/charts#21465

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- open shell of the nextcloud container
- manually execute:
```
occ config:system:set jpeg_quality --value="60" --type=integer
occ config:system:set preview_max_x --value="2048" --type=integer
occ config:system:set preview_max_y --value="2048" --type=integer
occ config:system:set preview_max_memory --value="1024" --type=integer
occ config:system:set preview_max_filesize_image --value="50" --type=integer
```
- check if error is gone

**📃 Notes:**
<!-- Please enter any other relevant information here -->
Theres already an issue in the Memories repo (https://github.com/pulsejet/memories/issues/1168) and an open PR tat Nextcloud AIO (https://github.com/nextcloud/all-in-one/pull/4617).

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
